### PR TITLE
Fix unicode encoding problem when importing calendars from sources…

### DIFF
--- a/ical2csv.py
+++ b/ical2csv.py
@@ -64,7 +64,7 @@ def csv_write(icsfile):
             wr = csv.writer(myfile, quoting=csv.QUOTE_ALL)
             wr.writerow(headers)
             for event in events:
-                values = (event.summary, event.uid, event.description, event.location, event.start, event.end, event.url)
+                values = (event.summary.encode('utf-8'), event.uid, event.description.encode('utf-8'), event.location, event.start, event.end, event.url)
                 wr.writerow(values)
             print("Wrote to ", csvfile, "\n")
     except IOError:


### PR DESCRIPTION
…like gmail.

This fixed an error in csv_write, which is caused by wr.writerow(values), which is in turn caused by improper encoding of the fields summary and description. I didn't want to get ahead of myself and also fix location which didn't cause errors in my situation, but might cause errors for others because of the same reason.