### PR TITLE
Skip blank description to prevent encode error

### DIFF
--- a/ical2csv.py
+++ b/ical2csv.py
@@ -36,6 +36,7 @@ def open_cal():
                 if component.get('SUMMARY') == None: continue #skip blank items
                 event.summary = component.get('SUMMARY')
                 event.uid = component.get('UID')
+                if component.get('DESCRIPTION') == None: continue #skip blank items
                 event.description = component.get('DESCRIPTION')
                 event.location = component.get('LOCATION')
                 if hasattr(component.get('dtstart'), 'dt'):


### PR DESCRIPTION
Might make more sense to allow for blank and encode an empty string.